### PR TITLE
Add GO111MODULE env variable to travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
 install:
   - # Skip
 
+env:
+  - GO111MODULE=on
+
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d .)


### PR DESCRIPTION
Add GO111MODULE env variable to enable build of go modules inside go path of travis. To move to docker soon.